### PR TITLE
Support Redactor-fields in django admin inlines

### DIFF
--- a/redactor/static/django-redactor/redactor/admin_setup.js
+++ b/redactor/static/django-redactor/redactor/admin_setup.js
@@ -1,0 +1,58 @@
+var Redactor = (function ($) {
+    // Redactor palette attributes will accumulate here.
+    var redactor_attrs = [];
+    // Initialize all textareas with the ``redactor_content`` class
+    // as a Redactor rich text area.
+    $(document).ready(function () {
+        var redactor_fields = $("textarea.redactor_content");
+        if (redactor_fields.length !== redactor_attrs.length) {
+            window.alert("Number of registered attributes does not match the widget count.");
+        }
+
+        // Model fields
+        var model_redactor_fields = $("form > div > .module textarea.redactor_content");
+        model_redactor_fields.each(function (i) {
+            var settings = redactor_attrs[i];
+            $(this).parent("div").find("label").addClass("redactor_label");
+            $(this).redactor(settings);
+        });
+
+        // Inlines
+        var inline_groups_with_redactor = [];
+        var count_inline_fields = 0;
+
+        // Fill inline groups with redactor widgets
+        $("form > div > .inline-group").each(function() {
+            if ($(this).find('.module textarea.redactor_content').length)
+                inline_groups_with_redactor.push($(this));
+        });
+
+        // Init redactor on inlines
+        $.each(inline_groups_with_redactor, function () {
+            var inline_fields = $(this).find("textarea.redactor_content");
+            var last_inline_field_num = model_redactor_fields.length + (count_inline_fields + inline_fields.length);
+            var settings = redactor_attrs[last_inline_field_num-1];
+            count_inline_fields += inline_fields.length;
+
+            // Init redactor on displayed (or extra) inlines
+            $(this).find(".inline-related:not(.empty-form) textarea.redactor_content").each(function () {
+                 $(this).parent("div").find("label").addClass("redactor_label");
+                 $(this).redactor(settings);
+            });
+
+            // Init redactor on new added inline
+            $(this).on('DOMNodeInserted', '.inline-related:not(.redactor_label)', function() {
+                $(this).addClass('redactor_label');
+                $(this).find('textarea.redactor_content').redactor(settings);
+            });
+
+        });
+    });
+
+    return {
+        register: function () {
+            var attrs = arguments.length !== 0 ? arguments[0] : null;
+            redactor_attrs.push(attrs);
+        }
+    };
+})(jQuery);

--- a/redactor/static/django-redactor/redactor/css/django_admin.css
+++ b/redactor/static/django-redactor/redactor/css/django_admin.css
@@ -1,10 +1,15 @@
 .redactor_box {
-    width: 900px;
+    float: left;
+    width: 900px
 }
 .redactor_box.wide {
     width: 1200px
 }
 label.redactor_label {
-    float: none;
-    padding-bottom: 10px;
+    float: left;
+    padding-bottom: 10px
+}
+form .aligned .redactor_editor p {
+    margin-left: 0;
+    padding-left: 0
 }

--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -11,7 +11,6 @@ except ImportError:
     from urllib.parse import urljoin
 
 
-
 from django.conf import settings
 from django.forms import Media, Textarea
 from django.utils.safestring import mark_safe
@@ -86,7 +85,6 @@ class RedactorEditor(Textarea):
     def _get_js_media(self):
         js = (
             'django-redactor/redactor/redactor.min.js',
-            'django-redactor/redactor/setup.js',
         )
         if self.include_jquery:
             js = ('django-redactor/lib/jquery-1.9.0.min.js',) + js
@@ -107,6 +105,7 @@ class RedactorEditor(Textarea):
         js = self._get_js_media()
         if self.redactor_settings['lang'] != 'en':
             js += ('django-redactor/redactor/langs/%s.js' % self.redactor_settings['lang'],)
+        js += ('django-redactor/redactor/setup.js',)
         css = {
             'screen': [
                 'django-redactor/redactor/css/redactor.css',
@@ -133,6 +132,7 @@ class AdminRedactorEditor(RedactorEditor):
         js = self._get_js_media()
         if self.redactor_settings['lang'] != 'en':
             js += ('django-redactor/redactor/langs/%s.js' % self.redactor_settings['lang'],)
+        js += ('django-redactor/redactor/admin_setup.js',)
         css = {
             'screen': [
                 'django-redactor/redactor/css/redactor.css',


### PR DESCRIPTION
Editor's fields was displayed, but didn't work in django admin inlines.
I fix this...
